### PR TITLE
Added HealthCheck groups 

### DIFF
--- a/samples/SampleHealthChecker.AspNet/Global.asax.cs
+++ b/samples/SampleHealthChecker.AspNet/Global.asax.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.Extensions.HealthChecks;
 
@@ -16,10 +15,18 @@ namespace SampleHealthChecker.AspNet
             GlobalHealthChecks.Builder
                 .WithDefaultCacheDuration(TimeSpan.FromMinutes(1))
                 .AddUrlCheck("https://github.com")
-                .AddPrivateMemorySizeCheck(1)
-                .AddVirtualMemorySizeCheck(2)
-                .AddWorkingSetCheck(1)
-                .AddUrlChecks(new List<string> { "https://github.com", "https://google.com", "https://twitddter.com" }, "servers")
+                .AddHealthCheckGroup(
+                    "servers",
+                    group => group.AddUrlCheck("https://github.com")
+                                  .AddUrlCheck("https://google.com")
+                                  .AddUrlCheck("https://twitddter.com")
+                )
+                .AddHealthCheckGroup(
+                    "memory",
+                    group => group.AddPrivateMemorySizeCheck(1)
+                                  .AddVirtualMemorySizeCheck(2)
+                                  .AddWorkingSetCheck(1)
+                )
                 .AddCheck("thrower", (Func<IHealthCheckResult>)(() => { throw new DivideByZeroException(); }))
                 .AddCheck("long-running", async cancellationToken => { await Task.Delay(10000, cancellationToken); return HealthCheckResult.Healthy("I ran too long"); });
         }

--- a/samples/SampleHealthChecker.AspNetCore/Startup.cs
+++ b/samples/SampleHealthChecker.AspNetCore/Startup.cs
@@ -32,12 +32,20 @@ namespace SampleHealthChecker
         {
             services.AddHealthChecks(checks =>
             {
-                checks.WithDefaultCacheDuration(TimeSpan.FromMinutes(1))
-                      .AddUrlCheck("https://github.com")
-                      .AddPrivateMemorySizeCheck(1)
-                      .AddVirtualMemorySizeCheck(2)
-                      .AddWorkingSetCheck(1)
-                      .AddUrlChecks(new List<string> { "https://github.com", "https://google.com", "https://twitddter.com" }, "servers")
+                checks.AddUrlCheck("https://github.com")
+                      .AddHealthCheckGroup(
+                          "servers",
+                          group => group.AddUrlCheck("https://github.com")
+                                        .AddUrlCheck("https://google.com")
+                                        .AddUrlCheck("https://twitddter.com")
+                      )
+                      .AddHealthCheckGroup(
+                          "memory",
+                          group => group.AddPrivateMemorySizeCheck(1)
+                                        .AddVirtualMemorySizeCheck(2)
+                                        .AddWorkingSetCheck(1),
+                          CheckStatus.Unhealthy
+                      )
                       .AddCheck("thrower", (Func<IHealthCheckResult>)(() => { throw new DivideByZeroException(); }))
                       .AddCheck("long-running", async cancellationToken => { await Task.Delay(10000, cancellationToken); return HealthCheckResult.Healthy("I ran too long"); });
 

--- a/src/Microsoft.Extensions.HealthChecks/Checks/GroupCheck.cs
+++ b/src/Microsoft.Extensions.HealthChecks/Checks/GroupCheck.cs
@@ -1,0 +1,44 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Microsoft.Extensions.HealthChecks
+{
+    public static partial class HealthCheckBuilderExtensions
+    {
+        public static HealthCheckBuilder AddHealthCheckGroup(this HealthCheckBuilder builder, string groupName,
+                                                             Action<HealthCheckBuilder> innerChecks)
+            => AddHealthCheckGroup(builder, groupName, innerChecks, CheckStatus.Warning);
+
+        public static HealthCheckBuilder AddHealthCheckGroup(this HealthCheckBuilder builder, string groupName,
+                                                             Action<HealthCheckBuilder> innerChecks,
+                                                             CheckStatus partiallyHealthyStatus)
+        {
+            Guard.ArgumentNotNull(nameof(builder), builder);
+            Guard.ArgumentNotNullOrWhitespace(nameof(groupName), groupName);
+            Guard.ArgumentNotNull(nameof(innerChecks), innerChecks);
+
+            var innerBuilder = new HealthCheckBuilder();
+            innerChecks(innerBuilder);
+
+            builder.AddCheck($"Group({groupName})", async cancellationToken =>
+            {
+                var result = new CompositeHealthCheckResult(partiallyHealthyStatus);
+                var checkResults = innerBuilder.Checks.Select(check => new { Name = check.Key, Operation = check.Value.CheckAsync(cancellationToken).AsTask() }).ToList();
+                await Task.WhenAll(checkResults.Select(x => x.Operation)).ConfigureAwait(false);
+
+                foreach (var checkResult in checkResults)
+                {
+                    result.Add(checkResult.Name, checkResult.Operation.Result);
+                }
+
+                return result;
+            });
+
+            return builder;
+        }
+    }
+}

--- a/test/Microsoft.Extensions.HealthChecks.Test/Checks/GroupCheckTest.cs
+++ b/test/Microsoft.Extensions.HealthChecks.Test/Checks/GroupCheckTest.cs
@@ -1,0 +1,149 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Xunit;
+
+namespace Microsoft.Extensions.HealthChecks.Checks
+{
+    public class GroupCheckTest
+    {
+        HealthCheckBuilder builder = new HealthCheckBuilder();
+
+        [Fact]
+        public void GuardClauses()
+        {
+            Assert.Throws<ArgumentNullException>("builder", () => HealthCheckBuilderExtensions.AddHealthCheckGroup(null, null, null));
+            Assert.Throws<ArgumentNullException>("groupName", () => HealthCheckBuilderExtensions.AddHealthCheckGroup(builder, null, null));
+            Assert.Throws<ArgumentException>("groupName", () => HealthCheckBuilderExtensions.AddHealthCheckGroup(builder, String.Empty, null));
+            Assert.Throws<ArgumentNullException>("innerChecks", () => HealthCheckBuilderExtensions.AddHealthCheckGroup(builder, "groupName", null));
+        }
+
+        [Fact]
+        public async void AddNoCheckToGroup()
+        {
+            builder.AddHealthCheckGroup("NoChecks", group => { });
+
+            var checks = builder.Checks;
+            foreach (var check in checks)
+            {
+                var result = await check.Value.CheckAsync() as CompositeHealthCheckResult;
+                Assert.NotNull(result);
+                Assert.Equal(result.CheckStatus, CheckStatus.Unknown);
+                Assert.Equal(result.Results.Count, 0);
+            }
+        }
+
+        [Fact]
+        public async void AddSingleUnhealthyCheckToGroupShouldReturnUnhealthy()
+        {
+            builder.AddHealthCheckGroup("NoChecks", group =>
+            {
+                group.AddCheck("Unhealthy", () => HealthCheckResult.Unhealthy("Unhealthy"));
+            });
+
+            var checks = builder.Checks;
+            foreach (var check in checks)
+            {
+                var result = await check.Value.CheckAsync() as CompositeHealthCheckResult;
+                Assert.NotNull(result);
+                Assert.Equal(result.CheckStatus, CheckStatus.Unhealthy);
+                Assert.Equal(result.Results.Count, 1);
+            }
+        }
+
+        [Fact]
+        public async void AddSingleHealthyCheckToGroupShouldReturnHealthy()
+        {
+            builder.AddHealthCheckGroup("NoChecks", group =>
+            {
+                group.AddCheck("Healthy", () => HealthCheckResult.Healthy("Healthy"));
+            });
+
+            var checks = builder.Checks;
+            foreach (var check in checks)
+            {
+                var result = await check.Value.CheckAsync() as CompositeHealthCheckResult;
+                Assert.NotNull(result);
+                Assert.Equal(result.CheckStatus, CheckStatus.Healthy);
+                Assert.Equal(result.Results.Count, 1);
+            }
+        }
+
+        [Fact]
+        public async void AddTwoUnhealthyCheckToGroupShouldReturnUnhealthy()
+        {
+            builder.AddHealthCheckGroup("NoChecks", group =>
+            {
+                group.AddCheck("Unhealthy_1", () => HealthCheckResult.Unhealthy("Unhealthy"));
+                group.AddCheck("Unhealthy_2", () => HealthCheckResult.Unhealthy("Unhealthy"));
+            });
+
+            var checks = builder.Checks;
+            foreach (var check in checks)
+            {
+                var result = await check.Value.CheckAsync() as CompositeHealthCheckResult;
+                Assert.NotNull(result);
+                Assert.Equal(result.CheckStatus, CheckStatus.Unhealthy);
+                Assert.Equal(result.Results.Count, 2);
+            }
+        }
+
+        [Fact]
+        public async void AddTwoHealthyCheckToGroupShouldReturnHealthy()
+        {
+            builder.AddHealthCheckGroup("NoChecks", group =>
+            {
+                group.AddCheck("Healthy_1", () => HealthCheckResult.Healthy("Healthy"));
+                group.AddCheck("Healthy_2", () => HealthCheckResult.Healthy("Healthy"));
+            });
+
+            var checks = builder.Checks;
+            foreach (var check in checks)
+            {
+                var result = await check.Value.CheckAsync() as CompositeHealthCheckResult;
+                Assert.NotNull(result);
+                Assert.Equal(result.CheckStatus, CheckStatus.Healthy);
+                Assert.Equal(result.Results.Count, 2);
+            }
+        }
+
+        [Fact]
+        public async void AddOneHealthyAndOneUnhealthyCheckToGroupShouldReturnWarning()
+        {
+            builder.AddHealthCheckGroup("NoChecks", group =>
+            {
+                group.AddCheck("Healthy", () => HealthCheckResult.Healthy("Healthy"));
+                group.AddCheck("Unhealthy", () => HealthCheckResult.Unhealthy("Unhealthy"));
+            });
+
+            var checks = builder.Checks;
+            foreach (var check in checks)
+            {
+                var result = await check.Value.CheckAsync() as CompositeHealthCheckResult;
+                Assert.NotNull(result);
+                Assert.Equal(result.CheckStatus, CheckStatus.Warning);
+                Assert.Equal(result.Results.Count, 2);
+            }
+        }
+
+        [Fact]
+        public async void AddOneHealthyAndOneUnhealthyCheckToGroupShouldReturnUnhealthy()
+        {
+            builder.AddHealthCheckGroup("NoChecks", group =>
+            {
+                group.AddCheck("Healthy", () => HealthCheckResult.Healthy("Healthy"));
+                group.AddCheck("Unhealthy", () => HealthCheckResult.Unhealthy("Unhealthy"));
+            }, CheckStatus.Unhealthy);
+
+            var checks = builder.Checks;
+            foreach (var check in checks)
+            {
+                var result = await check.Value.CheckAsync() as CompositeHealthCheckResult;
+                Assert.NotNull(result);
+                Assert.Equal(result.CheckStatus, CheckStatus.Unhealthy);
+                Assert.Equal(result.Results.Count, 2);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Added HealthCheck groups to group multiple checks to a single check as discussed in the old repository: https://github.com/aspnet/AspLabs/issues/13

Grouping may help to handle a group of checks in a different way than another group or than single checks. 

A similar PR is already in the old repository. The HealthCheckResult changed a little bit and the new CompositeHealthCheckResult makes the grouping a lot easier. This is why the AddHealthCheckGroup extension method now is much smaller, than in the old PR :)

ASP.NET Core
![image](https://cloud.githubusercontent.com/assets/365688/24199774/34d73ebc-0f0b-11e7-99f4-46858c1ab62e.png)

ASP.NET
![image](https://cloud.githubusercontent.com/assets/365688/24200932/e5f47284-0f0e-11e7-9680-b83bde7f738a.png)
