### PR TITLE
UrlChecker should wait for any HTTP succesful state code.

### DIFF
--- a/src/Microsoft.Extensions.HealthChecks/Internal/UrlChecker.cs
+++ b/src/Microsoft.Extensions.HealthChecks/Internal/UrlChecker.cs
@@ -75,7 +75,7 @@ namespace Microsoft.Extensions.HealthChecks.Internal
         public static async ValueTask<IHealthCheckResult> DefaultUrlCheck(HttpResponseMessage response)
         {
             // REVIEW: Should this be an explicit 200 check, or just an "is success" check?
-            var status = response.StatusCode == HttpStatusCode.OK ? CheckStatus.Healthy : CheckStatus.Unhealthy;
+            var status = response.IsSuccessStatusCode ? CheckStatus.Healthy : CheckStatus.Unhealthy;
             var data = new Dictionary<string, object>
             {
                 { "url", response.RequestMessage.RequestUri.ToString() },


### PR DESCRIPTION
Currently UrlChecker expects only a 200 HTTP Status code

Any valid HTTP OK status code should be valid (i.e. thinking about a "Ping" URL that returns just a 204)