### PR TITLE
Extract CachedHealthCheck base class

### DIFF
--- a/src/Microsoft.Extensions.HealthChecks/CachedHealthCheck.cs
+++ b/src/Microsoft.Extensions.HealthChecks/CachedHealthCheck.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Extensions.HealthChecks
+{
+    public abstract class CachedHealthCheck : IHealthCheck
+    {
+        private DateTimeOffset _cacheExpiration;
+        private volatile int _writerCount;
+
+        protected CachedHealthCheck(TimeSpan cacheDuration)
+        {
+            Guard.ArgumentValid(cacheDuration >= TimeSpan.Zero, nameof(cacheDuration), "Cache duration must either be zero (disabled) or a positive value");
+
+            CacheDuration = cacheDuration;
+        }
+
+        protected IHealthCheckResult CachedResult { get; private set; }
+
+        public virtual TimeSpan CacheDuration { get; }
+
+        protected virtual DateTimeOffset UtcNow => DateTimeOffset.UtcNow;
+
+        public async ValueTask<IHealthCheckResult> CheckAsync(CancellationToken cancellationToken)
+        {
+            while (_cacheExpiration <= UtcNow)
+            {
+                // Can't use a standard lock here because of async, so we'll use this flag to determine when we should write a value,
+                // and the waiters who aren't allowed to write will just spin wait for the new value.
+                if (Interlocked.Exchange(ref _writerCount, 1) != 0)
+                {
+                    await Task.Delay(5, cancellationToken).ConfigureAwait(false);
+                    continue;
+                }
+
+                try
+                {
+                    CachedResult = await ExecuteCheckAsync(cancellationToken).ConfigureAwait(false);
+                    _cacheExpiration = UtcNow + CacheDuration;
+                    break;
+                }
+                finally
+                {
+                    _writerCount = 0;
+                }
+            }
+
+            return CachedResult;
+        }
+
+        /// <summary>
+        /// Override to provide the health check implementation. The results will
+        /// automatically be cached based on <see cref="CacheDuration"/>, and if
+        /// needed, the previously cached value is available via <see cref="CachedResult"/>.
+        /// </summary>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        protected abstract ValueTask<IHealthCheckResult> ExecuteCheckAsync(CancellationToken cancellationToken);
+    }
+}

--- a/src/Microsoft.Extensions.HealthChecks/HealthCheck.cs
+++ b/src/Microsoft.Extensions.HealthChecks/HealthCheck.cs
@@ -7,53 +7,21 @@ using System.Threading.Tasks;
 
 namespace Microsoft.Extensions.HealthChecks
 {
-    public class HealthCheck : IHealthCheck
+    public class HealthCheck : CachedHealthCheck
     {
-        private DateTimeOffset _cacheExpiration;
-        private IHealthCheckResult _cachedResult;
-        private volatile int _writerCount;
-
-        protected HealthCheck(Func<CancellationToken, ValueTask<IHealthCheckResult>> check, TimeSpan cacheDuration)
+        protected HealthCheck(
+            Func<CancellationToken, ValueTask<IHealthCheckResult>> check,
+            TimeSpan cacheDuration) : base(cacheDuration)
         {
             Guard.ArgumentNotNull(nameof(check), check);
-            Guard.ArgumentValid(cacheDuration >= TimeSpan.Zero, nameof(cacheDuration), "Cache duration must either be zero (disabled) or a positive value");
 
             Check = check;
-            CacheDuration = cacheDuration;
         }
-
-        public TimeSpan CacheDuration { get; }
 
         protected Func<CancellationToken, ValueTask<IHealthCheckResult>> Check { get; }
 
-        protected virtual DateTimeOffset UtcNow => DateTimeOffset.UtcNow;
-
-        public async ValueTask<IHealthCheckResult> CheckAsync(CancellationToken cancellationToken)
-        {
-            while (_cacheExpiration <= UtcNow)
-            {
-                // Can't use a standard lock here because of async, so we'll use this flag to determine when we should write a value,
-                // and the waiters who aren't allowed to write will just spin wait for the new value.
-                if (Interlocked.Exchange(ref _writerCount, 1) != 0)
-                {
-                    await Task.Delay(5, cancellationToken).ConfigureAwait(false);
-                    continue;
-                }
-
-                try
-                {
-                    _cachedResult = await Check(cancellationToken).ConfigureAwait(false);
-                    _cacheExpiration = UtcNow + CacheDuration;
-                    break;
-                }
-                finally
-                {
-                    _writerCount = 0;
-                }
-            }
-
-            return _cachedResult;
-        }
+        protected override ValueTask<IHealthCheckResult> ExecuteCheckAsync(CancellationToken cancellationToken)
+            => Check(cancellationToken);
 
         public static HealthCheck FromCheck(Func<IHealthCheckResult> check, TimeSpan cacheDuration)
             => new HealthCheck(token => new ValueTask<IHealthCheckResult>(check()), cacheDuration);


### PR DESCRIPTION
This removes the `Func<>` requirement to use the caching functionality of the health check base class. `HealthCheck` remains as the cached, `Func<>`-based implementation.