### PR TITLE
WIP on supporting DI for IHealthCheck instances

### DIFF
--- a/src/Microsoft.AspNet.HealthChecks/GlobalHealthChecks.cs
+++ b/src/Microsoft.AspNet.HealthChecks/GlobalHealthChecks.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.Extensions.HealthChecks  // Put this in Extensions so you also have access to all the helper methods
@@ -7,11 +8,12 @@ namespace Microsoft.Extensions.HealthChecks  // Put this in Extensions so you al
     {
         static GlobalHealthChecks()
         {
+            // REVIEW: Should we add a way to override the service collection, or just assume no DI here?
             var logger = new LoggerFactory().CreateLogger<HealthCheckService>();
 
-            Builder = new HealthCheckBuilder();
+            Builder = new HealthCheckBuilder(null);
             HandlerCheckTimeout = TimeSpan.FromSeconds(10);
-            Service = new HealthCheckService(Builder, logger);
+            Service = HealthCheckService.FromBuilder(Builder, logger);
         }
 
         public static HealthCheckBuilder Builder { get; }

--- a/src/Microsoft.Extensions.HealthChecks/CheckExecutor.cs
+++ b/src/Microsoft.Extensions.HealthChecks/CheckExecutor.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.Extensions.HealthChecks
 {
@@ -12,6 +13,17 @@ namespace Microsoft.Extensions.HealthChecks
     /// </summary>
     public class CheckExecutor
     {
+        public static IHealthCheck ResolveCheck(object value, IServiceProvider serviceProvider)
+        {
+            if (value is IHealthCheck healthCheck)
+                return healthCheck;
+
+            if (value is Type healthCheckType)
+                return (IHealthCheck)serviceProvider.GetRequiredService(healthCheckType);
+
+            throw new InvalidOperationException("Unexpected check value; should be Type or IHealthCheck");
+        }
+
         public static ValueTask<IHealthCheckResult> RunCheckAsync(IHealthCheck healthCheck, CancellationToken cancellationToken)
         {
             Guard.ArgumentNotNull(nameof(healthCheck), healthCheck);

--- a/src/Microsoft.Extensions.HealthChecks/HealthCheckServiceCollectionExtensions.cs
+++ b/src/Microsoft.Extensions.HealthChecks/HealthCheckServiceCollectionExtensions.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Extensions.DependencyInjection
     {
         public static IServiceCollection AddHealthChecks(this IServiceCollection services, Action<HealthCheckBuilder> checkupAction)
         {
-            var checkupBuilder = new HealthCheckBuilder();
+            var checkupBuilder = new HealthCheckBuilder(services);
 
             checkupAction.Invoke(checkupBuilder);
 

--- a/test/Microsoft.Extensions.HealthChecks.Test/Checks/NumericChecksTest.cs
+++ b/test/Microsoft.Extensions.HealthChecks.Test/Checks/NumericChecksTest.cs
@@ -3,13 +3,14 @@
 
 using System;
 using System.Linq;
+using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
 namespace Microsoft.Extensions.HealthChecks.Checks
 {
     public class NumericChecksTest
     {
-        HealthCheckBuilder builder = new HealthCheckBuilder();
+        HealthCheckBuilder builder = new HealthCheckBuilder(new ServiceCollection());
 
         public class AddMinValueCheck : NumericChecksTest
         {
@@ -29,7 +30,7 @@ namespace Microsoft.Extensions.HealthChecks.Checks
             {
                 builder.AddMinValueCheck("CheckName", 0, () => monitoredValue);
 
-                var check = builder.Checks["CheckName"];
+                var check = (IHealthCheck)builder.Checks["CheckName"];
 
                 var result = await check.CheckAsync();
                 Assert.Equal(expectedStatus, result.CheckStatus);
@@ -67,7 +68,7 @@ namespace Microsoft.Extensions.HealthChecks.Checks
             {
                 builder.AddMaxValueCheck("CheckName", 0, () => monitoredValue);
 
-                var check = builder.Checks["CheckName"];
+                var check = (IHealthCheck)builder.Checks["CheckName"];
 
                 var result = await check.CheckAsync();
                 Assert.Equal(expectedStatus, result.CheckStatus);

--- a/test/Microsoft.Extensions.HealthChecks.Test/HealthCheckServiceTest.cs
+++ b/test/Microsoft.Extensions.HealthChecks.Test/HealthCheckServiceTest.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Linq;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.HealthChecks.Fakes;
 using Xunit;
 
@@ -16,9 +17,9 @@ namespace Microsoft.Extensions.HealthChecks
 
         public HealthCheckServiceTest()
         {
-            _builder = new HealthCheckBuilder();
+            _builder = new HealthCheckBuilder(new ServiceCollection());
             _logger = new FakeLogger<HealthCheckService>();
-            _classUnderTest = new HealthCheckService(_builder, _logger);
+            _classUnderTest = HealthCheckService.FromBuilder(_builder, _logger);
         }
 
         [Fact]

--- a/test/Microsoft.Extensions.HealthChecks.Test/Microsoft.Extensions.HealthChecks.Test.csproj
+++ b/test/Microsoft.Extensions.HealthChecks.Test/Microsoft.Extensions.HealthChecks.Test.csproj
@@ -6,6 +6,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="1.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\..\src\Microsoft.Extensions.HealthChecks\Microsoft.Extensions.HealthChecks.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
I'm not super happy with how this turned out, so I'm definitely looking for feedback.

TL;DR: We want to be able to support DI for `IHealthCheck` implementors, without introducing DI as a requirement for ASP.NET. A new registration method is added (`HealthCheckBuilder.AddCheck<TCheck>(string name)`) which allows the user to specify a type that should be resolved via DI. The communication between the builder and the service becomes a fairly ugly `Dictionary<string, object>` where the value might be an existing `IHealthCheck` instance, or might be a `Type` that should be resolved via the `IServiceProvider`.

When operating without a DI'd implementation of `IServiceProvider`, we use a simple singleton provider that uses `Activator.CreateInstance` (which means implementations here don't get real DI support). There is, in my mind, an open question about whether ASP.NET should support some kind of user-provided DI, or whether we continue to just directly [create the infrastructure we need](https://github.com/aspnet/HealthChecks/blob/913601fcadbfbd997f32c940d08c08f5f06e00df/src/Microsoft.AspNet.HealthChecks/GlobalHealthChecks.cs#L11-L16) without DI.

/tag @Eilon @glennc @DamianEdwards @davidfowl 