### PR TITLE
simple checks for Couchbase, Redis and Elastic

### DIFF
--- a/HealthChecks.sln
+++ b/HealthChecks.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26228.9
+VisualStudioVersion = 15.0.26730.12
 MinimumVisualStudioVersion = 15.0.26228.4
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "samples", "samples", "{E05DCF88-F916-4B61-A5DC-A8344C9E2429}"
 EndProject
@@ -24,6 +24,8 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.AspNet.HealthChecks", "src\Microsoft.AspNet.HealthChecks\Microsoft.AspNet.HealthChecks.csproj", "{2AE82E1C-6CE1-4755-A332-FA359B7CCE72}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SampleHealthChecker.AspNet", "samples\SampleHealthChecker.AspNet\SampleHealthChecker.AspNet.csproj", "{33FB5967-62C7-4230-B515-780EF63F748E}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Extensions.HealthChecks.Couchbase", "src\Microsoft.Extensions.HealthChecks.Couchbase\Microsoft.Extensions.HealthChecks.Couchbase.csproj", "{4FF659AF-7F2A-43B9-A2F9-E32950598E9F}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -63,6 +65,10 @@ Global
 		{33FB5967-62C7-4230-B515-780EF63F748E}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{33FB5967-62C7-4230-B515-780EF63F748E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{33FB5967-62C7-4230-B515-780EF63F748E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4FF659AF-7F2A-43B9-A2F9-E32950598E9F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4FF659AF-7F2A-43B9-A2F9-E32950598E9F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4FF659AF-7F2A-43B9-A2F9-E32950598E9F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4FF659AF-7F2A-43B9-A2F9-E32950598E9F}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -76,5 +82,9 @@ Global
 		{13BE838A-200B-4A68-8F58-3EA3BE3A1A8A} = {F9BA869A-7D5F-420F-9505-2D881F7934A7}
 		{2AE82E1C-6CE1-4755-A332-FA359B7CCE72} = {F9BA869A-7D5F-420F-9505-2D881F7934A7}
 		{33FB5967-62C7-4230-B515-780EF63F748E} = {E05DCF88-F916-4B61-A5DC-A8344C9E2429}
+		{4FF659AF-7F2A-43B9-A2F9-E32950598E9F} = {F9BA869A-7D5F-420F-9505-2D881F7934A7}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {27CEE543-FC4E-4CA0-BD5F-6B966A5E1953}
 	EndGlobalSection
 EndGlobal

--- a/HealthChecks.sln
+++ b/HealthChecks.sln
@@ -27,6 +27,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SampleHealthChecker.AspNet"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Extensions.HealthChecks.Couchbase", "src\Microsoft.Extensions.HealthChecks.Couchbase\Microsoft.Extensions.HealthChecks.Couchbase.csproj", "{4FF659AF-7F2A-43B9-A2F9-E32950598E9F}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Extensions.HealthChecks.Elastic", "src\Microsoft.Extensions.HealthChecks.Elastic\Microsoft.Extensions.HealthChecks.Elastic.csproj", "{A6B58EF5-DD7F-47C4-82AF-6054B55B4DBB}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Extensions.HealthChecks.Redis", "src\Microsoft.Extensions.HealthChecks.Redis\Microsoft.Extensions.HealthChecks.Redis.csproj", "{DF328324-E98E-4EBE-BC89-8789E71EE371}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -69,6 +73,14 @@ Global
 		{4FF659AF-7F2A-43B9-A2F9-E32950598E9F}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{4FF659AF-7F2A-43B9-A2F9-E32950598E9F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{4FF659AF-7F2A-43B9-A2F9-E32950598E9F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A6B58EF5-DD7F-47C4-82AF-6054B55B4DBB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A6B58EF5-DD7F-47C4-82AF-6054B55B4DBB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A6B58EF5-DD7F-47C4-82AF-6054B55B4DBB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A6B58EF5-DD7F-47C4-82AF-6054B55B4DBB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DF328324-E98E-4EBE-BC89-8789E71EE371}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DF328324-E98E-4EBE-BC89-8789E71EE371}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DF328324-E98E-4EBE-BC89-8789E71EE371}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DF328324-E98E-4EBE-BC89-8789E71EE371}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -83,6 +95,8 @@ Global
 		{2AE82E1C-6CE1-4755-A332-FA359B7CCE72} = {F9BA869A-7D5F-420F-9505-2D881F7934A7}
 		{33FB5967-62C7-4230-B515-780EF63F748E} = {E05DCF88-F916-4B61-A5DC-A8344C9E2429}
 		{4FF659AF-7F2A-43B9-A2F9-E32950598E9F} = {F9BA869A-7D5F-420F-9505-2D881F7934A7}
+		{A6B58EF5-DD7F-47C4-82AF-6054B55B4DBB} = {F9BA869A-7D5F-420F-9505-2D881F7934A7}
+		{DF328324-E98E-4EBE-BC89-8789E71EE371} = {F9BA869A-7D5F-420F-9505-2D881F7934A7}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {27CEE543-FC4E-4CA0-BD5F-6B966A5E1953}

--- a/samples/SampleHealthChecker.AspNetCore/SampleHealthChecker.AspNetCore.csproj
+++ b/samples/SampleHealthChecker.AspNetCore/SampleHealthChecker.AspNetCore.csproj
@@ -8,6 +8,8 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\Microsoft.AspNetCore.HealthChecks\Microsoft.AspNetCore.HealthChecks.csproj" />
     <ProjectReference Include="..\..\src\Microsoft.Extensions.HealthChecks.Couchbase\Microsoft.Extensions.HealthChecks.Couchbase.csproj" />
+    <ProjectReference Include="..\..\src\Microsoft.Extensions.HealthChecks.Elastic\Microsoft.Extensions.HealthChecks.Elastic.csproj" />
+    <ProjectReference Include="..\..\src\Microsoft.Extensions.HealthChecks.Redis\Microsoft.Extensions.HealthChecks.Redis.csproj" />
     <ProjectReference Include="..\..\src\Microsoft.Extensions.HealthChecks\Microsoft.Extensions.HealthChecks.csproj" />
   </ItemGroup>
 

--- a/samples/SampleHealthChecker.AspNetCore/SampleHealthChecker.AspNetCore.csproj
+++ b/samples/SampleHealthChecker.AspNetCore/SampleHealthChecker.AspNetCore.csproj
@@ -7,6 +7,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Microsoft.AspNetCore.HealthChecks\Microsoft.AspNetCore.HealthChecks.csproj" />
+    <ProjectReference Include="..\..\src\Microsoft.Extensions.HealthChecks.Couchbase\Microsoft.Extensions.HealthChecks.Couchbase.csproj" />
     <ProjectReference Include="..\..\src\Microsoft.Extensions.HealthChecks\Microsoft.Extensions.HealthChecks.csproj" />
   </ItemGroup>
 
@@ -20,7 +21,7 @@
     <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="1.0.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="1.0.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="1.0.2" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="1.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="1.1.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="1.0.2" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="1.0.2" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="1.0.2" />

--- a/samples/SampleHealthChecker.AspNetCore/Startup.cs
+++ b/samples/SampleHealthChecker.AspNetCore/Startup.cs
@@ -9,6 +9,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.HealthChecks;
 using Microsoft.Extensions.Logging;
+using Couchbase;
 
 namespace SampleHealthChecker
 {
@@ -31,7 +32,7 @@ namespace SampleHealthChecker
         {
             // When doing DI'd health checks, you must register them as services of their concrete type
             services.AddSingleton<CustomHealthCheck>();
-
+            
             services.AddHealthChecks(checks =>
             {
                 checks.AddUrlCheck("https://github.com")
@@ -51,6 +52,9 @@ namespace SampleHealthChecker
                       .AddCheck("long-running", async cancellationToken => { await Task.Delay(10000, cancellationToken); return HealthCheckResult.Healthy("I ran too long"); })
                       .AddCheck<CustomHealthCheck>("custom");
 
+                ClusterHelper.Initialize();
+
+                checks.AddCouchbaseCheck(Configuration.GetValue<string>("COUCHBASE_CLUSTER_USER"), Configuration.GetValue<string>("COUCHBASE_CLUSTER_PASSWORD"), TimeSpan.FromSeconds(10));
                 /*
                 // add valid storage account credentials first
                 checks.AddAzureBlobStorageCheck("accountName", "accountKey");
@@ -86,7 +90,7 @@ namespace SampleHealthChecker
             {
                 app.UseExceptionHandler("/Home/Error");
             }
-
+            
             app.UseStaticFiles();
 
             app.UseMvc(routes =>

--- a/samples/SampleHealthChecker.AspNetCore/Startup.cs
+++ b/samples/SampleHealthChecker.AspNetCore/Startup.cs
@@ -38,10 +38,10 @@ namespace SampleHealthChecker
         {
             // When doing DI'd health checks, you must register them as services of their concrete type
             services.AddSingleton<CustomHealthCheck>();
-            services.AddSingleton<IConnectionMultiplexer>(ConnectionMultiplexer.Connect(Configuration.GetValue<string>("REDIS_CLUSTER_SERVERS")));
+            //services.AddSingleton<IConnectionMultiplexer>(ConnectionMultiplexer.Connect(Configuration.GetValue<string>("REDIS_CLUSTER_SERVERS")));
 
-            RegisterCouchbase(services);
-            RegisterElastic(services);
+            //RegisterCouchbase(services);
+            //RegisterElastic(services);
 
             services.AddHealthChecks(checks =>
             {
@@ -64,9 +64,9 @@ namespace SampleHealthChecker
 
                
 
-                checks.AddCouchbaseCheck(services,TimeSpan.FromSeconds(10));
-                checks.AddRedisCheck(services, TimeSpan.FromSeconds(10));
-                checks.AddElasticCheck(services, TimeSpan.FromSeconds(10));
+                //checks.AddCouchbaseCheck(services,TimeSpan.FromSeconds(10));
+                //checks.AddRedisCheck(services, TimeSpan.FromSeconds(10));
+                //checks.AddElasticCheck(services, TimeSpan.FromSeconds(10));
 
                 /*
                 // add valid storage account credentials first

--- a/src/Microsoft.AspNet.HealthChecks/Microsoft.AspNet.HealthChecks.csproj
+++ b/src/Microsoft.AspNet.HealthChecks/Microsoft.AspNet.HealthChecks.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net46</TargetFramework>
+    <Version>1.0.0-alpha</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Microsoft.AspNetCore.HealthChecks/Microsoft.AspNetCore.HealthChecks.csproj
+++ b/src/Microsoft.AspNetCore.HealthChecks/Microsoft.AspNetCore.HealthChecks.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp1.0</TargetFramework>
+    <Version>1.0.0-alpha</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Microsoft.Extensions.HealthChecks.AzureStorage/Microsoft.Extensions.HealthChecks.AzureStorage.csproj
+++ b/src/Microsoft.Extensions.HealthChecks.AzureStorage/Microsoft.Extensions.HealthChecks.AzureStorage.csproj
@@ -6,6 +6,7 @@
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
+    <Version>1.0.0-alpha</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Microsoft.Extensions.HealthChecks.Couchbase/CouchbaseHealthCheck.cs
+++ b/src/Microsoft.Extensions.HealthChecks.Couchbase/CouchbaseHealthCheck.cs
@@ -1,0 +1,81 @@
+﻿using Couchbase;
+using Couchbase.Configuration.Server.Serialization;
+using Couchbase.Core;
+using Couchbase.Management;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Linq;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Extensions.HealthChecks
+{
+    public class CouchbaseHealthCheck : IHealthCheck
+    {
+        public const string Tag = "Couchbase Server";
+
+        private string _message { get; set; }
+
+        private readonly IClusterManager _connection;
+
+        private readonly ILogger _logger;
+
+        private readonly string _username;
+
+        private readonly string _password;
+
+        public CouchbaseHealthCheck(IClusterManager connection, ILoggerFactory loggerFactory)
+        {
+            _connection = connection;
+            _logger = loggerFactory?.CreateLogger<CouchbaseHealthCheck>();
+        }
+
+
+        public ValueTask<IHealthCheckResult> CheckAsync(CancellationToken cancellationToken = default(CancellationToken))
+            => new ValueTask<IHealthCheckResult>(Check(cancellationToken));
+
+
+        private async Task<IHealthCheckResult> Check(CancellationToken cancellationToken = default(CancellationToken))
+        {
+            var result = HealthCheckResult.FromStatus(CheckStatus.Unknown, "Unknown");
+            
+         
+            if (!ClusterHelper.Initialized || _connection == null)
+            {
+                return HealthCheckResult.FromStatus(CheckStatus.Unknown, $"Cluster not initialized");
+            }
+
+            try
+            {
+                var buckets = await _connection.ListBucketsAsync();
+                if (!buckets.Success)
+                {
+                    return HealthCheckResult.FromStatus(CheckStatus.Unknown, "Could not list any buckets");
+
+                }
+
+                var unhealthy = from n in buckets?.Value?.SelectMany(x => x.Nodes) ?? Enumerable.Empty<Node>()
+                                where n != null && n.Status != "healthy"
+                                select n;
+
+                if (unhealthy.Any())
+                {
+                    result = HealthCheckResult.FromStatus(CheckStatus.Unhealthy, string.Join("\n", unhealthy.Select(x => $"{x.Hostname} : {x.Status}")));
+                }
+                else
+                {
+                    result = HealthCheckResult.FromStatus(CheckStatus.Healthy, "OK");
+                }
+            }
+            catch (HttpRequestException ex)
+            {
+                result = HealthCheckResult.FromStatus(CheckStatus.Unhealthy, ex.Message);
+                _logger?.LogError(new EventId(), ex, ex.Message);
+            }
+
+
+            return result;
+        }
+    }
+}

--- a/src/Microsoft.Extensions.HealthChecks.Couchbase/HealthCheckBuilderCouchbaseServerExtensions.cs
+++ b/src/Microsoft.Extensions.HealthChecks.Couchbase/HealthCheckBuilderCouchbaseServerExtensions.cs
@@ -1,0 +1,79 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Couchbase;
+using Couchbase.Management;
+using System;
+using System.Linq;
+using System.Net.Http;
+
+namespace Microsoft.Extensions.HealthChecks
+{
+    // REVIEW: What are the appropriate guards for these functions?
+
+    public static class HealthCheckBuilderCouchbaseServerExtensions
+    {
+        public static HealthCheckBuilder AddCouchbaseCheck(this HealthCheckBuilder builder, string username, string password)
+        {
+            Guard.ArgumentNotNull(nameof(builder), builder);
+
+            return AddCouchbaseCheck(builder, username, password, builder.DefaultCacheDuration);
+        }
+
+        public static HealthCheckBuilder AddCouchbaseCheck(this HealthCheckBuilder builder, string username, string password, TimeSpan cacheDuration)
+        {
+            builder.AddCheck($"CouchbaseCheck({username})", async () =>
+            {
+                var result = HealthCheckResult.Healthy($"CouchbaseCheck({username}): Healthy");
+
+                if (!ClusterHelper.Initialized)
+                {
+                    return HealthCheckResult.Unhealthy($"CouchbaseCheck({username}): Unhealthy");
+                }
+                    try
+                    {
+                        var cluster = ClusterHelper.Get();
+                        if (cluster == null)
+                        {
+
+                            return HealthCheckResult.Unhealthy($"CouchbaseCheck({username}): Unhealthy");
+                        }
+
+                        var manager = cluster.CreateManager(username, password);
+                        if (manager == null)
+                        {
+                            return HealthCheckResult.Unhealthy($"CouchbaseCheck({username}): Unhealthy");
+                        }
+
+                        var buckets = await manager.ListBucketsAsync();
+                        if (!buckets.Success)
+                        {
+                            return HealthCheckResult.Unhealthy($"CouchbaseCheck({username}): {buckets.Message}");
+
+                        }
+
+                        foreach (var bucket in buckets.Value)
+                        {
+                            foreach (var node in bucket.Nodes)
+                            {
+                                if (node.Status != "healthy")
+                                {
+                                    return HealthCheckResult.Unhealthy($"CouchbaseCheck({username}): Healthy");
+                                }
+                            }
+                        }
+                    }
+                    catch (HttpRequestException ex)
+                    {
+                    result = HealthCheckResult.Unhealthy(ex.Message);
+                    }
+                
+
+                return result;
+
+            }, cacheDuration);
+
+            return builder;
+        }
+    }
+}

--- a/src/Microsoft.Extensions.HealthChecks.Couchbase/Microsoft.Extensions.HealthChecks.Couchbase.csproj
+++ b/src/Microsoft.Extensions.HealthChecks.Couchbase/Microsoft.Extensions.HealthChecks.Couchbase.csproj
@@ -1,0 +1,20 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard1.5</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="..\common\Guard.cs" Link="Internal\Guard.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="CouchbaseNetClient" Version="2.5.2" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="1.1.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Microsoft.Extensions.HealthChecks\Microsoft.Extensions.HealthChecks.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Microsoft.Extensions.HealthChecks.Couchbase/Microsoft.Extensions.HealthChecks.Couchbase.csproj
+++ b/src/Microsoft.Extensions.HealthChecks.Couchbase/Microsoft.Extensions.HealthChecks.Couchbase.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard1.5</TargetFramework>
+    <Version>1.0.0-alpha</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Microsoft.Extensions.HealthChecks.Elastic/ElasticHealthCheck.cs
+++ b/src/Microsoft.Extensions.HealthChecks.Elastic/ElasticHealthCheck.cs
@@ -1,0 +1,56 @@
+﻿using Microsoft.Extensions.Logging;
+using Nest;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Extensions.HealthChecks
+{
+    public class ElasticHealthCheck : IHealthCheck
+    {
+        public const string Tag = "Elastic";
+
+        private string _message { get; set; }
+
+        private readonly IElasticClient _connection;
+
+        private readonly ILogger _logger;
+
+        public ElasticHealthCheck(IElasticClient connection, ILoggerFactory loggerFactory)
+        {
+            _connection = connection;
+            _logger = loggerFactory?.CreateLogger<ElasticHealthCheck>();
+        }
+
+
+        public ValueTask<IHealthCheckResult> CheckAsync(CancellationToken cancellationToken = default(CancellationToken))
+            => new ValueTask<IHealthCheckResult>(Check(cancellationToken));
+
+
+        private async Task<IHealthCheckResult> Check(CancellationToken cancellationToken = default(CancellationToken))
+        {
+            var result = HealthCheckResult.FromStatus(CheckStatus.Unknown, "Unknown");
+
+            try
+            {
+                var clusterHealth = await _connection.ClusterHealthAsync(new ClusterHealthRequest(), cancellationToken);
+                switch (clusterHealth?.Status)
+                {
+                    case "green":
+                        return HealthCheckResult.FromStatus(CheckStatus.Healthy, "Healthy");
+                    case "yellow":
+                        return HealthCheckResult.FromStatus(CheckStatus.Warning, "Warning");
+                    case "red":
+                        return HealthCheckResult.FromStatus(CheckStatus.Unhealthy, "Unhealthy");
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger?.LogError(new EventId(), ex, ex.Message);
+                result = HealthCheckResult.FromStatus(CheckStatus.Unhealthy, ex.Message);
+            }
+
+            return result;
+        }
+    }
+}

--- a/src/Microsoft.Extensions.HealthChecks.Elastic/HealthCheckBuilderElasticExtensions.cs
+++ b/src/Microsoft.Extensions.HealthChecks.Elastic/HealthCheckBuilderElasticExtensions.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using Couchbase;
-using Couchbase.Management;
 using Microsoft.Extensions.DependencyInjection;
 using System;
 using System.Linq;
@@ -12,14 +10,14 @@ namespace Microsoft.Extensions.HealthChecks
 {
     // REVIEW: What are the appropriate guards for these functions?
 
-    public static class HealthCheckBuilderCouchbaseServerExtensions
+    public static class HealthCheckBuilderRedisExtensions
     {
-        public static HealthCheckBuilder AddCouchbaseCheck(this HealthCheckBuilder builder, IServiceCollection services, TimeSpan? cacheDuration = null)
+        public static HealthCheckBuilder AddElasticCheck(this HealthCheckBuilder builder, IServiceCollection services, TimeSpan? cacheDuration = null)
         {
             Guard.ArgumentNotNull(nameof(builder), builder);
 
-            services.AddSingleton<CouchbaseHealthCheck>();
-            builder.AddCheck<CouchbaseHealthCheck>(CouchbaseHealthCheck.Tag, cacheDuration ?? builder.DefaultCacheDuration);
+            services.AddSingleton<ElasticHealthCheck>();
+            builder.AddCheck<ElasticHealthCheck>(ElasticHealthCheck.Tag, cacheDuration ?? builder.DefaultCacheDuration);
 
             return builder;
         }

--- a/src/Microsoft.Extensions.HealthChecks.Elastic/Microsoft.Extensions.HealthChecks.Elastic.csproj
+++ b/src/Microsoft.Extensions.HealthChecks.Elastic/Microsoft.Extensions.HealthChecks.Elastic.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard1.5</TargetFramework>
+    <Version>1.0.0-alpha</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Microsoft.Extensions.HealthChecks.Elastic/Microsoft.Extensions.HealthChecks.Elastic.csproj
+++ b/src/Microsoft.Extensions.HealthChecks.Elastic/Microsoft.Extensions.HealthChecks.Elastic.csproj
@@ -1,0 +1,20 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard1.5</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="..\common\Guard.cs" Link="Internal\Guard.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="1.1.0" />
+    <PackageReference Include="NEST" Version="5.5.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Microsoft.Extensions.HealthChecks\Microsoft.Extensions.HealthChecks.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Microsoft.Extensions.HealthChecks.Redis/HealthCheckBuilderRedisExtensions.cs
+++ b/src/Microsoft.Extensions.HealthChecks.Redis/HealthCheckBuilderRedisExtensions.cs
@@ -1,0 +1,23 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.Extensions.DependencyInjection;
+using System;
+
+namespace Microsoft.Extensions.HealthChecks
+{
+    // REVIEW: What are the appropriate guards for these functions?
+
+    public static class HealthCheckBuilderRedisExtensions
+    {
+        public static HealthCheckBuilder AddRedisCheck(this HealthCheckBuilder builder, IServiceCollection services, TimeSpan? cacheDuration = null)
+        {
+            Guard.ArgumentNotNull(nameof(builder), builder);
+
+            services.AddSingleton<RedisHealthCheck>();
+            builder.AddCheck<RedisHealthCheck>(RedisHealthCheck.Tag, cacheDuration ?? builder.DefaultCacheDuration);
+
+            return builder;
+        }
+    }
+}

--- a/src/Microsoft.Extensions.HealthChecks.Redis/Microsoft.Extensions.HealthChecks.Redis.csproj
+++ b/src/Microsoft.Extensions.HealthChecks.Redis/Microsoft.Extensions.HealthChecks.Redis.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard1.5</TargetFramework>
+    <Version>1.0.0-alpha</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Microsoft.Extensions.HealthChecks.Redis/Microsoft.Extensions.HealthChecks.Redis.csproj
+++ b/src/Microsoft.Extensions.HealthChecks.Redis/Microsoft.Extensions.HealthChecks.Redis.csproj
@@ -1,0 +1,20 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard1.5</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="..\common\Guard.cs" Link="Internal\Guard.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="1.1.0" />
+    <PackageReference Include="StackExchange.Redis" Version="1.2.6" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Microsoft.Extensions.HealthChecks\Microsoft.Extensions.HealthChecks.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Microsoft.Extensions.HealthChecks.Redis/RedisHealthCheck.cs
+++ b/src/Microsoft.Extensions.HealthChecks.Redis/RedisHealthCheck.cs
@@ -1,0 +1,85 @@
+﻿using Microsoft.Extensions.Logging;
+using StackExchange.Redis;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Extensions.HealthChecks
+{
+    public class RedisHealthCheck : IHealthCheck
+    {
+        public const string Tag = "Redis";
+
+        private string _message { get; set; }
+        
+        private readonly IConnectionMultiplexer _connection;
+
+        private readonly ILogger _logger;
+        
+        public RedisHealthCheck(IConnectionMultiplexer connection, ILoggerFactory loggerFactory)
+        {
+            _connection = connection;
+
+            if (_connection != null)
+            {
+                _connection.ConnectionFailed += _connection_ConnectionFailed;
+                _connection.ConnectionRestored += _connection_ConnectionRestored;
+            }
+
+            _logger = loggerFactory?.CreateLogger<RedisHealthCheck>();
+        }
+
+        private void _connection_ConnectionFailed(object sender, ConnectionFailedEventArgs e)
+        {
+            _message = $"{e.FailureType}";
+            if (e.Exception != null)
+            {
+                _logger?.LogError(new EventId(), e.Exception, _message);
+            }
+        }
+
+        private void _connection_ConnectionRestored(object sender, ConnectionFailedEventArgs e)
+        {
+            if (e?.FailureType == ConnectionFailureType.None)
+            {
+                _message = null;
+                _logger?.LogInformation(new EventId(), $"Connection restored on {e.EndPoint}");
+            }
+        }
+
+        public ValueTask<IHealthCheckResult> CheckAsync(CancellationToken cancellationToken = default(CancellationToken))
+            => new ValueTask<IHealthCheckResult>(Check());
+        
+
+        private Task<IHealthCheckResult> Check()
+        {
+            IHealthCheckResult result = HealthCheckResult.FromStatus(CheckStatus.Unknown, "Unknown");
+            if (_connection?.IsConnected != true)
+            {
+                result = HealthCheckResult.FromStatus(CheckStatus.Unhealthy, _message ?? "Not connected");
+            }
+
+            try
+            {
+                var status = _connection.GetStatus();
+                if (!status.Contains("int: ConnectedEstablished"))
+                {
+                    result = HealthCheckResult.FromStatus(CheckStatus.Unhealthy, status);
+                }
+                else
+                {
+                    result = HealthCheckResult.FromStatus(CheckStatus.Healthy, "OK");
+                }
+            }
+            catch (RedisException ex)
+            {
+                result = HealthCheckResult.FromStatus(CheckStatus.Unhealthy, ex.Message);
+            }
+
+            return Task.FromResult(result);
+        }
+    }
+}

--- a/src/Microsoft.Extensions.HealthChecks.SqlServer/Microsoft.Extensions.HealthChecks.SqlServer.csproj
+++ b/src/Microsoft.Extensions.HealthChecks.SqlServer/Microsoft.Extensions.HealthChecks.SqlServer.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard1.3</TargetFramework>
+    <Version>1.0.0-alpha</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Microsoft.Extensions.HealthChecks/Microsoft.Extensions.HealthChecks.csproj
+++ b/src/Microsoft.Extensions.HealthChecks/Microsoft.Extensions.HealthChecks.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard1.3</TargetFramework>
+    <Version>1.0.0-alpha</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Microsoft.Extensions.HealthChecks/Microsoft.Extensions.HealthChecks.csproj
+++ b/src/Microsoft.Extensions.HealthChecks/Microsoft.Extensions.HealthChecks.csproj
@@ -9,7 +9,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="1.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="1.1.0" />
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
     <PackageReference Include="System.Diagnostics.Process" Version="4.3.0" />
     <PackageReference Include="System.Threading.Tasks.Parallel" Version="4.3.0" />


### PR DESCRIPTION
the extensions depend on DI and use 3rd party libraries.

For Couchbase & Elastic the library is provided by the vendor.
For Redis i am using the StackExchange.Redis library

from a builder perspective it would be helpfull to have the IServiceCollection available there so you can add the checks to DI without the need to pass in the IServiceCollection from the signature.