### PR TITLE
Set explicit order, default for CheckStatus enum members

### DIFF
--- a/src/Microsoft.Extensions.HealthChecks/CheckStatus.cs
+++ b/src/Microsoft.Extensions.HealthChecks/CheckStatus.cs
@@ -5,9 +5,9 @@ namespace Microsoft.Extensions.HealthChecks
 {
     public enum CheckStatus
     {
-        Unknown,
-        Unhealthy,
+        Unknown = 0,
         Healthy,
-        Warning
+        Warning,
+        Unhealthy,
     }
 }


### PR DESCRIPTION
I would like to propose setting an explicit default value for the `CheckStatus` enum, so that uninitialized variables get the expected value of `Unknown`. This will communicate to developers that they can count on this default value.

I would also like to propose ordering the enum values from lowest to highest urgency, similar to e.g. `Microsoft.Extensions.Logging.LogLevel`. This makes it trivial to do things like find the most critical result from this collection (`var worst = checks.Max()`), find all checks which are warning or worse (`var alerts = checks.Where(ch => ch >= CheckStatus.Warning)`), sort them by urgency, etc. This is needed when a single collection point gathers checks from multiple locations and "bubbles them up" for display, alerting, etc.

I could not find anywhere in the solution that is currently depending on the order or explicit values from this enum, so there should be no negative impact from this change.